### PR TITLE
Typo fix

### DIFF
--- a/hashtables.cabal
+++ b/hashtables.cabal
@@ -191,7 +191,7 @@ Library
 
   if !flag(portable) && flag(unsafe-tricks) && impl(ghc)
     build-depends: ghc-prim
-    cpp-options = -DUNSAFETRICKS
+    cpp-options: -DUNSAFETRICKS
 
   if flag(debug)
     cpp-options: -DDEBUG


### PR DESCRIPTION
`cpp-options` should be specified with a colon (`:`) rather than an equals sign (`=`). At least, as far as I can tell. cabal gives a warning on that line saying "Unexpected section 'cpp-options' on line 182".
