### PR TITLE
Fix the FFI binding for c_lineSearch_3

### DIFF
--- a/src/Data/HashTable/Internal/CacheLine.hs
+++ b/src/Data/HashTable/Internal/CacheLine.hs
@@ -56,7 +56,7 @@ foreign import ccall unsafe "line_search"
 foreign import ccall unsafe "line_search_2"
   c_lineSearch_2 :: Ptr a -> CInt -> CUShort -> CUShort -> IO CInt
 
-foreign import ccall unsafe "line_search_2"
+foreign import ccall unsafe "line_search_3"
   c_lineSearch_3 :: Ptr a -> CInt -> CUShort -> CUShort -> CUShort -> IO CInt
 
 foreign import ccall unsafe "forward_search_2"


### PR DESCRIPTION
It was calling line_search_2, which caused problems with the GHC LLVM backend, as the number of arguments don't match.