### PR TITLE
Add lookupIndex and nextByIndex functions

### DIFF
--- a/src/Data/HashTable/Class.hs
+++ b/src/Data/HashTable/Class.hs
@@ -81,6 +81,15 @@ class HashTable h where
     -- table. /O(n)/.
     mapM_    :: ((k,v) -> ST s b) -> h s k v -> ST s ()
 
+    -- | Looks up the index of a key-value mapping in a hash table suitable
+    -- for passing to 'nextByIndex'.
+    lookupIndex :: (Eq k, Hashable k) => h s k v -> k -> ST s (Maybe Word)
+
+    -- | Returns the next key-value mapping stored at the given index or at
+    -- a greater index. The index, key, and value of the next record are
+    -- returned.
+    nextByIndex :: h s k v -> Word -> ST s (Maybe (Word,k,v))
+
     -- | Computes the overhead (in words) per key-value mapping. Used for
     -- debugging, etc; time complexity depends on the underlying hash table
     -- implementation. /O(n)/.

--- a/src/Data/HashTable/IO.hs
+++ b/src/Data/HashTable/IO.hs
@@ -53,6 +53,8 @@ module Data.HashTable.IO
   , mapM_
   , foldM
   , computeOverhead
+  , lookupIndex
+  , nextByIndex
   ) where
 
 
@@ -150,6 +152,31 @@ lookup h k = stToIO $ C.lookup h k
 {-# SPECIALIZE INLINE lookup :: (Eq k, Hashable k) =>
                          CuckooHashTable k v -> k -> IO (Maybe v) #-}
 
+------------------------------------------------------------------------------
+-- | See the documentation for this function in "Data.HashTable.Class#v:lookupIndex".
+lookupIndex   :: (C.HashTable h, Eq k, Hashable k) =>
+                 IOHashTable h k v -> k -> IO (Maybe Word)
+lookupIndex h k = stToIO $ C.lookupIndex h k
+{-# INLINE lookupIndex #-}
+{-# SPECIALIZE INLINE lookupIndex :: (Eq k, Hashable k) =>
+                         BasicHashTable  k v -> k -> IO (Maybe Word) #-}
+{-# SPECIALIZE INLINE lookupIndex :: (Eq k, Hashable k) =>
+                         LinearHashTable k v -> k -> IO (Maybe Word) #-}
+{-# SPECIALIZE INLINE lookupIndex :: (Eq k, Hashable k) =>
+                         CuckooHashTable k v -> k -> IO (Maybe Word) #-}
+
+------------------------------------------------------------------------------
+-- | See the documentation for this function in "Data.HashTable.Class#v:nextByIndex".
+nextByIndex   :: (C.HashTable h, Eq k, Hashable k) =>
+                 IOHashTable h k v -> Word -> IO (Maybe (Word,k,v))
+nextByIndex h k = stToIO $ C.nextByIndex h k
+{-# INLINE nextByIndex #-}
+{-# SPECIALIZE INLINE nextByIndex :: (Eq k, Hashable k) =>
+                         BasicHashTable  k v -> Word -> IO (Maybe (Word,k,v)) #-}
+{-# SPECIALIZE INLINE nextByIndex :: (Eq k, Hashable k) =>
+                         LinearHashTable k v -> Word -> IO (Maybe (Word,k,v)) #-}
+{-# SPECIALIZE INLINE nextByIndex :: (Eq k, Hashable k) =>
+                         CuckooHashTable k v -> Word -> IO (Maybe (Word,k,v)) #-}
 
 ------------------------------------------------------------------------------
 -- | See the documentation for this function in

--- a/src/Data/HashTable/Internal/Linear/Bucket.hs
+++ b/src/Data/HashTable/Internal/Linear/Bucket.hs
@@ -238,7 +238,7 @@ lookupIndex bucketKey !k
   | keyIsEmpty bucketKey = return Nothing
   | otherwise = lookup' $ fromKey bucketKey
   where
-    lookup' (Bucket _ hwRef keys values) = do
+    lookup' (Bucket _ hwRef keys _values) = do
         hw <- readSTRef hwRef
         go (hw-1)
       where

--- a/src/Data/HashTable/Internal/Utils.hs
+++ b/src/Data/HashTable/Internal/Utils.hs
@@ -51,7 +51,7 @@ cacheLineSize = 64
 numElemsInCacheLine :: Int
 numElemsInCacheLine = z
   where
-    !z = cacheLineSize `div` (bitSize (0::Elem) `div` 8)
+    !z = cacheLineSize `div` (finiteBitSize (0::Elem) `div` 8)
 
 
 -- | What you have to mask an integer index by to tell if it's

--- a/src/Data/HashTable/ST/Basic.hs
+++ b/src/Data/HashTable/ST/Basic.hs
@@ -702,7 +702,6 @@ lookupIndex htRef !k = do
                      if k == k'
                        then do
                          debug $ "value found at " ++ show idx
-                         v <- readArray values idx
                          return $! (Just $! fromIntegral idx)
                        else do
                          debug $ "value not found, recursing"

--- a/src/Data/HashTable/ST/Basic.hs
+++ b/src/Data/HashTable/ST/Basic.hs
@@ -668,7 +668,7 @@ lookupIndex htRef !k = do
     ht <- readRef htRef
     lookup' ht
   where
-    lookup' (HashTable sz _ hashes keys values) = do
+    lookup' (HashTable sz _ hashes keys _values) = do
         let !b = whichBucket h sz
         debug $ "lookup h=" ++ show h ++ " sz=" ++ show sz ++ " b=" ++ show b
         go b 0 sz

--- a/src/Data/HashTable/ST/Cuckoo.hs
+++ b/src/Data/HashTable/ST/Cuckoo.hs
@@ -70,6 +70,8 @@ module Data.HashTable.ST.Cuckoo
   , insert
   , mapM_
   , foldM
+  , lookupIndex
+  , nextByIndex
   ) where
 
 
@@ -128,6 +130,8 @@ instance C.HashTable HashTable where
     lookup          = lookup
     foldM           = foldM
     mapM_           = mapM_
+    lookupIndex     = lookupIndex
+    nextByIndex     = nextByIndex
     computeOverhead = computeOverhead
 
 
@@ -692,3 +696,44 @@ writeRef (HT ref) ht = writeSTRef ref ht
 readRef :: HashTable s k v -> ST s (HashTable_ s k v)
 readRef (HT ref) = readSTRef ref
 {-# INLINE readRef #-}
+
+
+------------------------------------------------------------------------------
+
+-- | Find index of given key in the hashtable.
+lookupIndex :: (Hashable k, Eq k) => HashTable s k v -> k -> ST s (Maybe Word)
+lookupIndex htRef k =
+  do HashTable sz _ hashes keys _ _ <- readRef htRef
+
+     let !h1  = hash1 k
+         !h2  = hash2 k
+         !he1 = hashToElem h1
+         !he2 = hashToElem h2
+         !b1  = whichLine h1 sz
+         !b2  = whichLine h2 sz
+
+     idx1 <- searchOne keys hashes k b1 he1
+     if idx1 >= 0
+       then return $! (Just $! fromIntegral idx1)
+       else do idx2 <- searchOne keys hashes k b2 he2
+               if idx2 >= 0
+                 then return $! (Just $! fromIntegral idx2)
+                 else return Nothing
+
+-- | Find the next entry in the hashtable starting at the given index.
+nextByIndex :: HashTable s k v -> Word -> ST s (Maybe (Word,k,v))
+nextByIndex htRef i0 =
+  do HashTable sz _ hashes keys values _ <- readRef htRef
+     let totSz = numElemsInCacheLine * sz
+         go i
+           | i >= totSz = return Nothing
+           | otherwise =
+               do h <- U.readArray hashes i
+                  if h == emptyMarker
+                    then go (i+1)
+                    else do k <- readArray keys i
+                            v <- readArray values i
+                            let !i' = fromIntegral i
+                            return (Just (i',k,v))
+
+     go (fromIntegral i0)

--- a/test/suite/Data/HashTable/Test/Common.hs
+++ b/test/suite/Data/HashTable/Test/Common.hs
@@ -25,8 +25,10 @@ import           Test.Framework
 import           Test.Framework.Providers.HUnit
 import           Test.Framework.Providers.QuickCheck2
 import           Test.HUnit                           (assertFailure)
-import           Test.QuickCheck
-import           Test.QuickCheck.Monadic
+import           Test.QuickCheck                      (arbitrary, choose,
+                                                       sample')
+import           Test.QuickCheck.Monadic              (PropertyM, assert,
+                                                       forAllM, monadicIO, run)
 ------------------------------------------------------------------------------
 import qualified Data.HashTable.Class                 as C
 import           Data.HashTable.Internal.Utils        (unsafeIOToST)


### PR DESCRIPTION
These functions are useful for enumerating through the elements of a hash-table in a manner suitable for being driven by an external process.
