### PR TITLE
allow vector-0.12

### DIFF
--- a/hashtables.cabal
+++ b/hashtables.cabal
@@ -175,7 +175,7 @@ Library
   Build-depends:     base      >= 4   && <5,
                      hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.3,
                      primitive,
-                     vector    >= 0.7 && <0.12
+                     vector    >= 0.7 && <0.13
 
   if flag(portable)
     cpp-options: -DNO_C_SEARCH -DPORTABLE


### PR DESCRIPTION
Seems to build fine against vector-0.12, though I haven't been able to figure out how to run the test suite.  This is holding up a few things on https://github.com/fpco/stackage/issues/2194 .