### PR TITLE
Add import for `pre`

### DIFF
--- a/benchmark/src/Criterion/Collection/Internal/Types.hs
+++ b/benchmark/src/Criterion/Collection/Internal/Types.hs
@@ -38,7 +38,7 @@ import           System.Random.MWC
 
 ------------------------------------------------------------------------------
 newtype WorkloadMonad a = WM (ReaderT GenIO IO a)
-  deriving (Monad, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadIO)
 
 
 ------------------------------------------------------------------------------

--- a/test/suite/Data/HashTable/Test/Common.hs
+++ b/test/suite/Data/HashTable/Test/Common.hs
@@ -29,7 +29,7 @@ import           Test.Framework.Providers.QuickCheck2
 import           Test.HUnit                           (assertFailure)
 import           Test.QuickCheck                      (arbitrary, choose,
                                                        sample')
-import           Test.QuickCheck.Monadic              (PropertyM, assert,
+import           Test.QuickCheck.Monadic              (PropertyM, assert, pre,
                                                        forAllM, monadicIO, run)
 ------------------------------------------------------------------------------
 import qualified Data.HashTable.Class                 as C


### PR DESCRIPTION
`Data.Hashtable.Test.Common` uses the function `pre`, but doesn't import it, so the tests don't compile at the moment.