### PR TITLE
Slot:  add Semigroup instance (GHC 8.4 compat)

### DIFF
--- a/src/Data/HashTable/ST/Basic.hs
+++ b/src/Data/HashTable/ST/Basic.hs
@@ -490,9 +490,16 @@ newtype Slot = Slot { _slot :: Int } deriving (Show)
 ------------------------------------------------------------------------------
 instance Monoid Slot where
     mempty = Slot maxBound
+#if !MIN_VERSION_base(4,11,0)
     (Slot x1) `mappend` (Slot x2) =
         let !m = mask x1 maxBound
         in Slot $! (complement m .&. x1) .|. (m .&. x2)
+#else
+instance Semigroup Slot where
+    (Slot x1) <> (Slot x2) =
+        let !m = mask x1 maxBound
+        in Slot $! (complement m .&. x1) .|. (m .&. x2)
+#endif
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #45. Tested with GHC 8.4.1-alpha1, 8.0.2.