### PR TITLE
add support for both primitive >=0.7 and < 0.7

### DIFF
--- a/src/Data/HashTable/Internal/IntArray.hs
+++ b/src/Data/HashTable/Internal/IntArray.hs
@@ -112,4 +112,8 @@ length (IA a) = A.sizeofMutableByteArray a `div` wordSizeInBytes
 toPtr :: IntArray s -> Ptr a
 toPtr (IA a) = Ptr a#
   where
+#if MIN_VERSION_primitive(0,7,0)
+    !(Ptr !a#) = A.mutableByteArrayContents a
+#else
     !(Addr !a#) = A.mutableByteArrayContents a
+#endif


### PR DESCRIPTION
this fixes hashtables to work with newer primitive