### PR TITLE
Add upper bound on primitive

### DIFF
--- a/hashtables.cabal
+++ b/hashtables.cabal
@@ -175,7 +175,7 @@ Library
 
   Build-depends:     base      >= 4.7 && <5,
                      hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.3,
-                     primitive,
+                     primitive < 0.7,
                      vector    >= 0.7 && <0.13
 
   if flag(portable)


### PR DESCRIPTION
This prevents a bad build plan with primitive 0.7.0.0

As a hackage trustee, I've made a metadata revision with this bound to version 1.2.3.2