### PR TITLE
Make it build with primitive >= 0.6 && < 0.8

### DIFF
--- a/hashtables.cabal
+++ b/hashtables.cabal
@@ -175,7 +175,7 @@ Library
 
   Build-depends:     base      >= 4.7 && <5,
                      hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.3,
-                     primitive,
+                     primitive >= 0.6 && <0.8,
                      vector    >= 0.7 && <0.13
 
   if flag(portable)

--- a/hashtables.cabal
+++ b/hashtables.cabal
@@ -174,7 +174,7 @@ Library
                      Data.HashTable.Internal.Linear.Bucket
 
   Build-depends:     base      >= 4.7 && <5,
-                     hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.3,
+                     hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.4,
                      primitive >= 0.6 && <0.8,
                      vector    >= 0.7 && <0.13
 

--- a/src/Data/HashTable/Internal/IntArray.hs
+++ b/src/Data/HashTable/Internal/IntArray.hs
@@ -20,7 +20,10 @@ module Data.HashTable.Internal.IntArray
 import           Control.Monad.ST
 import           Data.Bits
 import qualified Data.Primitive.ByteArray as A
+#if MIN_VERSION_primitive(0,7,0)
+#else
 import           Data.Primitive.Types     (Addr (..))
+#endif
 import           GHC.Exts
 import           GHC.Word
 import           Prelude                  hiding (length)


### PR DESCRIPTION
Would be nice to have a release with this as well.

The version on Hackage already has a [revision](https://hackage.haskell.org/package/hashtables-1.2.3.2/revisions/), but that just limits it to `primitive < 0.7`.