### PR TITLE
Fixed compilation with GHC 8.8.1

### DIFF
--- a/hashtables.cabal
+++ b/hashtables.cabal
@@ -185,7 +185,7 @@ Library
                      Data.HashTable.Internal.Linear.Bucket
 
   Build-depends:     base      >= 4.7 && <5,
-                     hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.3,
+                     hashable  >= 1.1 && <1.2 || >= 1.2.1 && <1.4,
                      primitive,
                      vector    >= 0.7 && <0.13
 


### PR DESCRIPTION
GHC 8.8.1-alpha2 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2019-June/017777.html). In this PR I fixed the compilation with this version of GHC. 

Blocking https://github.com/agda/agda/issues/3725.