### PR TITLE
Make the mode an integer constant expression in cmp_mask

### DIFF
--- a/cbits/sse-42.c
+++ b/cbits/sse-42.c
@@ -49,8 +49,7 @@ static inline __m128i fill(small_hash_t v) {
 #define _MODE (SIDD_UWORD_OPS | SIDD_CMP_EQUAL_EACH)
 
 static inline __m128i cmp_mask(__m128i a, __m128i b) {
-    const int mode = SIDD_UWORD_OPS | SIDD_CMP_EQUAL_EACH | SIDD_BIT_MASK;
-    return _mm_cmpistrm(a, b, mode);
+    return _mm_cmpistrm(a, b, _MODE | SIDD_BIT_MASK);
 }
 
 static inline int32_t line_result(uint32_t m, int start) {


### PR DESCRIPTION
I ran into a problem when I was compiling with Clang + SSE4.2
This code is invalid in clang compiler
```c
const int mode = SIDD_UWORD_OPS | SIDD_CMP_EQUAL_EACH | SIDD_BIT_MASK;
return _mm_cmpistrm(a, b, mode);
```
Because **_mm_cmpistrm** takes mode as an integer constant expression, not a const qualified int.
For instance assume this code:
```c
#include <smmintrin.h>

#define SIDD_UWORD_OPS _SIDD_UWORD_OPS
#define SIDD_CMP_EQUAL_EACH _SIDD_CMP_EQUAL_EACH
#define SIDD_BIT_MASK _SIDD_BIT_MASK

static inline __m128i cmp_mask(__m128i a, __m128i b) {
    const int mode = SIDD_UWORD_OPS | SIDD_CMP_EQUAL_EACH | SIDD_BIT_MASK;
    return _mm_cmpistrm(a, b, mode);
}

int main(void) {
    return 0;
}
```
```console
$ clang -msse4.2 a.c -o a
a.c:11:9: error: argument to '__builtin_ia32_pcmpistrm128' must be a constant integer
        return _mm_cmpistrm(a, b, mode);
               ^~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/llvm/14/bin/../../../../lib/clang/14.0.6/include/smmintrin.h:1629:13: note: expanded from macro '_mm_cmpistrm'
  ((__m128i)__builtin_ia32_pcmpistrm128((__v16qi)(__m128i)(A), \
            ^
1 error generated.
```
I think other compilers like GCC have no problem if we use
```c
return _mm_cmpistrm(a, b, SIDD_UWORD_OPS | SIDD_CMP_EQUAL_EACH | SIDD_BIT_MASK);
```
