### PR TITLE
Fix warnings

### DIFF
--- a/src/Data/HashTable/Internal/IntArray.hs
+++ b/src/Data/HashTable/Internal/IntArray.hs
@@ -106,8 +106,8 @@ writeArray (IA a) idx val = do
 
 
 ------------------------------------------------------------------------------
-length :: IntArray s -> Int
-length (IA a) = A.sizeofMutableByteArray a `div` wordSizeInBytes
+length :: IntArray s -> ST s Int
+length (IA a) = (`div` wordSizeInBytes) <$> A.getSizeofMutableByteArray a
 
 
 ------------------------------------------------------------------------------

--- a/test/suite/Data/HashTable/Test/Common.hs
+++ b/test/suite/Data/HashTable/Test/Common.hs
@@ -15,7 +15,7 @@ module Data.HashTable.Test.Common
 import           Control.Applicative                  (pure, (<$>))
 #endif
 import           Control.Applicative                  ((<|>))
-import           Control.Monad                        (foldM_, liftM, when)
+import           Control.Monad                        (foldM_, when)
 import qualified Control.Monad                        as Monad
 import           Data.IORef
 import           Data.List                            hiding (delete, insert,
@@ -32,7 +32,7 @@ import           Test.Framework.Providers.QuickCheck2
 import           Test.HUnit                           (assertEqual,
                                                        assertFailure)
 import           Test.QuickCheck                      (arbitrary, choose,
-                                                       sample')
+                                                       generate)
 import           Test.QuickCheck.Monadic              (PropertyM, assert,
                                                        forAllM, monadicIO, pre,
                                                        run)
@@ -242,7 +242,7 @@ testGrowTable prefix dummyArg =
     prop n = do
         announceQ "growTable" n
         ht <- run $ go n
-        i <- liftM head $ run $ sample' $ choose (0,n-1)
+        i <- run $ generate $ choose (0,n-1)
 
         v <- run $ lookup ht i
         assertEq ("lookup " ++ show i) (Just i) v
@@ -290,7 +290,7 @@ testDelete prefix dummyArg =
 
         ht <- run $ go n
 
-        i <- liftM head $ run $ sample' $ choose (4,n-1)
+        i <- run $ generate $ choose (4,n-1)
         v <- run $ lookup ht i
         assertEq ("lookup " ++ show i) (Just i) v
 


### PR DESCRIPTION
* Replace deprecated `sizeofMutableByteArray` with `getSizeofMutableByteArray`.
* Remove use of `List.head` which generates a warning with later GHC versions. Completely un-needed anyway if `QuickCheck.sample'` is replaced with `QuickCheck.generate`.