### PR TITLE
defs.h: add parameters to check_impl_specific() for C23

### DIFF
--- a/cbits/defs.h
+++ b/cbits/defs.h
@@ -30,6 +30,6 @@ int line_search_3(small_hash_t* array, int start, small_hash_t x1,
 void suicide(volatile int* check, int i);
 
 void CHECK(int actual, int expected, char* what);
-void check_impl_specific();
+void check_impl_specific(int* num_tests, int* num_errors);
 
 #endif  /* HASHTABLES_DEFS_H */


### PR DESCRIPTION
This fixes the build with gcc15

Closes #92 